### PR TITLE
Treat __variable__ public

### DIFF
--- a/packaway/rules/tests/test_underscore_rule.py
+++ b/packaway/rules/tests/test_underscore_rule.py
@@ -13,6 +13,7 @@ class TestAnalyzerAPI(unittest.TestCase):
         good_sources = [
             "from . import module",
             "from .subpackage.module import name",
+            "from .subpackage.module import __name__",
             "from ._subpackage.module import name",
             "from package.module import name",
             "from ..subpackage.module import name",
@@ -47,6 +48,7 @@ class TestAnalyzerAPI(unittest.TestCase):
     def test_error_examples(self):
         bad_sources = [
             "from .._subpackage import _name",
+            "from .subpackage import __name",
             "from ._subpackage._module import name",
         ]
         for source in bad_sources:

--- a/packaway/rules/underscore_rule.py
+++ b/packaway/rules/underscore_rule.py
@@ -2,8 +2,22 @@
 """ This module supports disallowing imports using leading underscores and
 packaging structures.
 """
+import re
 
 from packaway.rules._ast_analyzer import ImportAnalyzer
+
+
+def _is_private_name(name):
+    """ Return true if the given variable name is considered private.
+
+    Parameters
+    ----------
+    name : str
+        Variable name to check
+    """
+    # e.g. __name__ is considered public.
+    is_reserved_public_name = re.match(r"__[a-zA-Z0-9_]+__$", name) is not None
+    return name.startswith("_") and not is_reserved_public_name
 
 
 def _is_valid_import(source_module, target_module):
@@ -41,7 +55,7 @@ def _is_valid_import(source_module, target_module):
         n_common_levels += 1
 
     for part in target_parts[n_common_levels + 1:]:
-        if part.startswith("_"):
+        if _is_private_name(part):
             return False, f"Importing private name {target_module!r}.",
     else:
         return True, ""


### PR DESCRIPTION
Assuming Python convention is observed, `__variable__` is reserved for Python builtin names. A lot of these names are public, for example, `__name__` is commonly used. This change allows imports of `__version__`, `__name__`, `__all__` and the likes without a violation error from the linter.